### PR TITLE
remove return from channel set/patch state

### DIFF
--- a/src/sdks/channels.ts
+++ b/src/sdks/channels.ts
@@ -157,7 +157,7 @@ export const channels = sdk(client => {
 			state: SetStateAction<T>,
 		) {
 			const id = typeof channel === 'object' ? channel.id : channel;
-			return updateState(id, state, 'set');
+			await updateState(id, state, 'set');
 		},
 
 		async patchState<T extends API.Channels.State>(
@@ -165,7 +165,7 @@ export const channels = sdk(client => {
 			state: SetStateAction<T>,
 		) {
 			const id = typeof channel === 'object' ? channel.id : channel;
-			return updateState(id, state, 'patch');
+			await updateState(id, state, 'patch');
 		},
 
 		/**


### PR DESCRIPTION
can either remove return statements from `setState` and `patchState` or add return statement to `updateState` and it's callers 